### PR TITLE
Bug fixes for mobile flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8622,7 +8622,7 @@
         },
         "packages/kikcode": {
             "name": "@code-wallet/kikcode",
-            "version": "1.0.5",
+            "version": "1.0.6",
             "license": "MIT",
             "dependencies": {
                 "@code-wallet/currency": "^1.0.0"
@@ -8874,7 +8874,7 @@
         },
         "packages/views": {
             "name": "@code-wallet/views",
-            "version": "1.0.5",
+            "version": "1.0.6",
             "license": "MIT",
             "dependencies": {
                 "@code-wallet/events": "^1.4.0",

--- a/packages/views/package.json
+++ b/packages/views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-wallet/views",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "license": "MIT",
   "repository": {
       "type": "git",

--- a/packages/views/src/components/sdk/CodeDesktopModal.vue
+++ b/packages/views/src/components/sdk/CodeDesktopModal.vue
@@ -76,9 +76,12 @@ channel.on("afterInvoke", async () => {
 
   if (request.value.hasMessage()) {
     const reqWithMessage = request.value as CodeRequestWithMessage;
+    await reqWithMessage.openStream(channel);
 
-    // intentionally ignoring the await here
-    reqWithMessage.openStream(channel);
+    // Intentionally ignoring the await here (stream is BIDI, it can't be
+    // awaited without blocking the UI)
+    reqWithMessage.listenForMessages();
+
   } else {
     request.value.generateKikCode();
   }

--- a/packages/views/src/components/sdk/CodeMobileModal.vue
+++ b/packages/views/src/components/sdk/CodeMobileModal.vue
@@ -86,9 +86,11 @@ channel.on("afterInvoke", async () => {
 
   if (request.value.hasMessage()) {
     const reqWithMessage = request.value as CodeRequestWithMessage;
+    await reqWithMessage.openStream(channel);
 
-    // intentionally ignoring the await here
-    reqWithMessage.openStream(channel);
+    // Intentionally ignoring the await here (stream is BIDI, it can't be
+    // awaited without blocking the UI)
+    reqWithMessage.listenForMessages();
   }
 
   // If we know the user has the app, then give the system prompt asking them if

--- a/packages/views/src/components/sdk/modals/LoginRequestModalMobile.vue
+++ b/packages/views/src/components/sdk/modals/LoginRequestModalMobile.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { LoginRequest } from "../../../requests";
-import { openInAppStore, openInApp } from "../../../utils";
+import { openInAppStore, openInApp, getAppUrl } from "../../../utils";
 import { CodeSpinner } from '../../common';
 
 import CodeMobileModal from '../CodeMobileModal.vue';
@@ -21,10 +21,13 @@ const props = defineProps({
       <div class="text-white text-[26px] px-16 text-center leading-tight
         tracking-tighter font-medium">Use the Code Wallet app to login</div>
 
-      <button v-if="!state.isLoading" type="button" @click="openInApp(channel, request.toPayload())" 
-      class="mt-6 block rounded-md bg-white py-4 text-base
-      font-semibold text-[#0f0c1f] text-center shadow-sm
-      w-full">Open in Code</button>
+      <a v-if="!state.isLoading" 
+        :href="getAppUrl(request.toPayload())" 
+        @click="openInApp(channel, request.toPayload(), 300)" 
+        class="mt-6 block rounded-md bg-white py-4 text-base
+        font-semibold text-[#0f0c1f] text-center shadow-sm
+        active:bg-[#0f0c1f] active:text-white active:border-white 
+        border border-transparent w-full">Open in Code</a>
 
       <button v-else type="button" 
       class="mt-6 block rounded-md bg-white py-4 text-base

--- a/packages/views/src/components/sdk/modals/PaymentRequestModalMobile.vue
+++ b/packages/views/src/components/sdk/modals/PaymentRequestModalMobile.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { PaymentRequest } from "../../../requests";
-import { openInAppStore, openInApp, formatCurrency } from "../../../utils";
+import { openInAppStore, openInApp, getAppUrl } from "../../../utils";
 import { CodeSpinner } from '../../common';
 
 import CodeMobileModal from '../CodeMobileModal.vue';
@@ -11,9 +11,6 @@ const props = defineProps({
   asPage: { type: Boolean, required: false, },
 });
 
-function getFormattedAmount(req: PaymentRequest) {
-  return formatCurrency(req.getAmount()!, req.getCurrency()!);
-}
 </script>
 
 <template>
@@ -24,10 +21,13 @@ function getFormattedAmount(req: PaymentRequest) {
       <div class="text-white text-[26px] px-16 text-center leading-tight
         tracking-tighter font-medium">Use the Code Wallet app to pay</div>
 
-      <button v-if="!state.isLoading" type="button" @click="openInApp(channel, request.toPayload())" 
-      class="mt-6 block rounded-md bg-white py-4 text-base
-      font-semibold text-[#0f0c1f] text-center shadow-sm
-      w-full">Open in Code</button>
+      <a v-if="!state.isLoading" 
+        :href="getAppUrl(request.toPayload())" 
+        @click="openInApp(channel, request.toPayload(), 300)" 
+        class="mt-6 block rounded-md bg-white py-4 text-base
+        font-semibold text-[#0f0c1f] text-center shadow-sm
+        active:bg-[#0f0c1f] active:text-white active:border-white 
+        border border-transparent w-full">Open in Code</a>
 
       <button v-else type="button" 
       class="mt-6 block rounded-md bg-white py-4 text-base

--- a/packages/views/src/components/sdk/modals/TipRequestModalMobile.vue
+++ b/packages/views/src/components/sdk/modals/TipRequestModalMobile.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { openInAppStore, openInApp, } from "../../../utils";
+import { openInAppStore, openInApp, getAppUrl } from "../../../utils";
 import { TipRequest, CodeRequest } from "../../../requests";
 import { CodeSpinner } from '../../common';
 
@@ -28,10 +28,13 @@ function getUsername(req: CodeRequest) {
       <div v-else class="text-white text-[26px] px-16 text-center leading-tight
         tracking-tighter font-medium">Use the Code Wallet app to tip</div>
 
-      <button v-if="!state.isLoading" type="button" @click="openInApp(channel, request.toPayload())" 
-      class="mt-6 block rounded-md bg-white py-4 text-base
-      font-semibold text-[#0f0c1f] text-center shadow-sm
-      w-full">Open in Code</button>
+      <a v-if="!state.isLoading" 
+        :href="getAppUrl(request.toPayload())" 
+        @click="openInApp(channel, request.toPayload(), 300)" 
+        class="mt-6 block rounded-md bg-white py-4 text-base
+        font-semibold text-[#0f0c1f] text-center shadow-sm
+        active:bg-[#0f0c1f] active:text-white active:border-white 
+        border border-transparent w-full">Open in Code</a>
 
       <button v-else type="button" 
       class="mt-6 block rounded-md bg-white py-4 text-base

--- a/packages/views/src/requests/CodeRequest.ts
+++ b/packages/views/src/requests/CodeRequest.ts
@@ -16,6 +16,7 @@ export interface CodeRequest {
 export type CodeRequestWithMessage = CodeRequest & {
     toProto(): Promise<proto.SendMessageRequest>;
     openStream(emitter: EventChannel<InternalEvents>): Promise<void>;
+    listenForMessages(): Promise<void>;
     closeStream(): void;
 }
 

--- a/packages/views/src/utils/user-agent/utils.ts
+++ b/packages/views/src/utils/user-agent/utils.ts
@@ -9,8 +9,7 @@ export function getAppStoreUrl() {
         url = 'https://apps.apple.com/us/app/code-wallet/id1562384846';
     } else {
         // Google Play Store URL
-        // url = 'https://play.google.com/store/apps/details?id=com.getcode';
-        url = 'https://www.getcode.com/download';
+        url = 'https://play.google.com/store/apps/details?id=com.getcode';
     }
 
     return url;
@@ -26,9 +25,11 @@ export function getAppUrl(payload: string) {
     return base.replace(/p=([^&]+)/, `p=${payload}`);
 }
 
-export function openInApp(channel: EventChannel<InternalEvents>, payload: string) {
-    const url = getAppUrl(payload);
-    channel.emit('navigate', { url });
+export function openInApp(channel: EventChannel<InternalEvents>, payload: string, delay: number = 0) {
+    setTimeout(() => {
+        const url = getAppUrl(payload);
+        channel.emit('navigate', { url });
+    }, delay);
 }
 
 export function hasCodeApp() {


### PR DESCRIPTION
This PR hopefully fixes a few issues with the `"Pay with Code"` button. The core symptom was that the button would not work in some browsers. The user would see no action when clicking the button. 

It is hard to say whether this will address the issues some users have reported, unfortunately this issue has been happening sporadically on some devices. Regardless, the changes here are in positive direction overall.

## Improved "Open in Code" Button:

Previously, the "Open in Code" button would use javascript to invoke a custom protocol handler to open the app. This was not working in all browsers, and was not a good user experience. The new implementation uses a simple anchor tag with a fallback to the javascript method.

This should hopefully fix the issue where the "Open in Code" button was not working in some browsers.

## Improved stream handling:

1) I’ve split out the logic for opening the stream and listening for messages on BIDI streams
2) We now await on the initial connection, but skip the awaiting on BIDI messages. Before we’d skip await on both.
3) If an error happens on the connection, it is now bubbled up to the UI.

### There are 2 cases where an error could happen:

1) The code server is unable to respond for some reason when asked about whether the intent has already been sent before (browsers are weird and this can happen on a back-button event)

2) The intent doesnt exist (happy path), but when sent, the server did not respond in a success message for some reason

Both these cases were not captured before. 

<img height="15%" src="https://github.com/user-attachments/assets/4b2167fd-cace-4872-83a5-9ac1650de27f">
<img height="15%" src="https://github.com/user-attachments/assets/3c745abd-ee9b-453e-89a6-b4b404d2e6df">

This is a small change, but it makes the code more robust and easier to debug.

## Download Code Button:

Android users were previously redirected to the website instead of the Play Store. This has been fixed.
