### PR TITLE
Docs | Added API Documentation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -22,15 +22,6 @@ export default defineConfig({
     ],
 
     sidebar: [
-      /*
-      {
-        text: 'Release Notes',
-        items: [
-          { text: 'Latest', link: '/release-notes' },
-          { text: 'Contribution Guide', link: '/guide/contribution-guide' },
-        ],
-      },
-      */
 
       {
         text: 'Getting Started',
@@ -63,7 +54,7 @@ export default defineConfig({
         items: [
           { text: 'Payments', link: '/intents/payment-requests' },
           { text: 'Fees', link: '/intents/payment-fees' },
-          { text: 'Tipping', link: '/intents/tipping' },
+          { text: 'Tips', link: '/intents/tipping' },
           { text: 'Login', link: '/intents/login' },
         ],
       },
@@ -71,17 +62,24 @@ export default defineConfig({
       {
         text: 'Examples',
         items: [
-          { text: 'Events', link: '/example/payment-events' },
           {
             text: 'Payments',
+            collapsed: true,
             items: [
               { text: 'Minimal (html)', link: '/example/request-payment' },
-              { text: 'React Example', link: '/example/react-example' },
-              { text: 'Vue Example', link: '/example/vue-example' },
-              { text: 'Pennypost', link: 'https://github.com/code-payments/code-pennypost/tree/main/packages/backend/src/routes/payment' },
+              { text: 'React', link: '/example/react-example' },
+              { text: 'Vue', link: '/example/vue-example' },
             ]
           },
-          { text: 'Verification', link: '/example/payment-verification' },
+          {
+            text: 'Login',
+            collapsed: true,
+            items: [
+              { text: 'Simple Login', link: 'https://github.com/code-payments/code-sdk/tree/main/examples/7-minimal-login' },
+              { text: 'Login With Payment', link: 'https://github.com/code-payments/code-sdk/tree/main/examples/6-minimal-purchase-with-login' },
+              { text: 'Pennypost', link: 'https://github.com/code-payments/code-pennypost/tree/main/packages/backend/src/routes/login' },
+            ]
+          },
           { text: 'More...', link: '/example/introduction' },
         ]
       },
@@ -90,8 +88,9 @@ export default defineConfig({
         text: 'Reference',
         items: [
           { text: 'Appearance', link: '/reference/element-appearance' },
-          { text: 'Custom Backends', link: '/intents/custom-backends' },
-          { text: 'Events', link: '/reference/browser-events' },
+          { text: 'Browser Events', link: '/reference/browser-events' },
+          { text: 'Payment Verification', link: '/example/payment-verification' },
+          { text: 'Payment Lifecycle', link: '/example/payment-events' },
           { text: 'Idempotency', link: '/reference/idempotency' },
           { text: 'Intents', link: '/intents/introduction' },
           { text: 'Private Payments', link: '/reference/splitter' },
@@ -100,6 +99,31 @@ export default defineConfig({
           { text: 'Timelock', link: '/reference/timelock' },
           { text: 'Wallet App', link: '/reference/app' },
           { text: 'Webhooks', link: '/reference/webhook' },
+        ]
+      },
+
+      {
+        text: 'gRPC API',
+        items: [
+          { text: 'Introduction', link: '/intents/custom-backends#code-api' },
+          {  
+            text: 'Getting Started', link: '/intents/custom-backends#getting-started',
+            collapsed: true,
+            items: [
+              { text: 'API Endpoints', link: '/intents/custom-backends#grpc-proxy' },
+              { text: 'Proto Defs', link: '/intents/custom-backends#protobuf' },
+              { text: 'Intents', link: '/intents/custom-backends#intents' },
+            ],
+          },
+          {  
+            text: 'Examples', link: '/intents/custom-backends#example-requests',
+            collapsed: true,
+            items: [
+              { text: 'Payments', link: '/intents/custom-backends#payment-requests' },
+              { text: 'Login', link: '/intents/custom-backends#login-intents' },
+            ],
+          },
+          { text: 'Contributing', link: '/intents/custom-backends#contributing' },
         ]
       },
     ],

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -50,16 +50,6 @@ export default defineConfig({
       },
 
       {
-        text: 'SDK',
-        items: [
-          { text: 'Payments', link: '/intents/payment-requests' },
-          { text: 'Fees', link: '/intents/payment-fees' },
-          { text: 'Tips', link: '/intents/tipping' },
-          { text: 'Login', link: '/intents/login' },
-        ],
-      },
-
-      {
         text: 'Examples',
         items: [
           {
@@ -85,6 +75,42 @@ export default defineConfig({
       },
 
       {
+        text: 'SDK (simple)',
+        items: [
+          { text: 'Payments', link: '/intents/payment-requests' },
+          { text: 'Fees', link: '/intents/payment-fees' },
+          { text: 'Tips', link: '/intents/tipping' },
+          { text: 'Login', link: '/intents/login' },
+        ],
+      },
+
+      {
+        text: 'API (advanced)', 
+        items: [
+          { text: 'Introduction', link: '/intents/custom-backends#introduction' },
+          {  
+            text: 'Getting Started', link: '/intents/custom-backends#getting-started',
+            collapsed: true,
+            items: [
+              { text: 'API Endpoints', link: '/intents/custom-backends#grpc-proxy' },
+              { text: 'Proto Defs', link: '/intents/custom-backends#protobuf' },
+              { text: 'Building Your Own Client', link: '/intents/custom-backends#building-a-client' },
+              { text: 'Intents', link: '/intents/custom-backends#intents' },
+            ],
+          },
+          {  
+            text: 'Examples',
+            collapsed: true,
+            items: [
+              { text: 'Payments', link: '/intents/custom-backends#payment-requests' },
+              { text: 'Login', link: '/intents/custom-backends#login-intents' },
+            ],
+          },
+          { text: 'Contributing', link: '/intents/custom-backends#contributing' },
+        ]
+      },
+
+      {
         text: 'Reference',
         items: [
           { text: 'Appearance', link: '/reference/element-appearance' },
@@ -99,31 +125,6 @@ export default defineConfig({
           { text: 'Timelock', link: '/reference/timelock' },
           { text: 'Wallet App', link: '/reference/app' },
           { text: 'Webhooks', link: '/reference/webhook' },
-        ]
-      },
-
-      {
-        text: 'gRPC API',
-        items: [
-          { text: 'Introduction', link: '/intents/custom-backends#code-api' },
-          {  
-            text: 'Getting Started', link: '/intents/custom-backends#getting-started',
-            collapsed: true,
-            items: [
-              { text: 'API Endpoints', link: '/intents/custom-backends#grpc-proxy' },
-              { text: 'Proto Defs', link: '/intents/custom-backends#protobuf' },
-              { text: 'Intents', link: '/intents/custom-backends#intents' },
-            ],
-          },
-          {  
-            text: 'Examples', link: '/intents/custom-backends#example-requests',
-            collapsed: true,
-            items: [
-              { text: 'Payments', link: '/intents/custom-backends#payment-requests' },
-              { text: 'Login', link: '/intents/custom-backends#login-intents' },
-            ],
-          },
-          { text: 'Contributing', link: '/intents/custom-backends#contributing' },
         ]
       },
     ],

--- a/docs/guide/introduction.md
+++ b/docs/guide/introduction.md
@@ -1,20 +1,14 @@
 # Introduction
 
-The Code SDK is the only payments platform that makes accepting small payments
-on the web simple. It’s open, permissionless, and requires just a few lines of
-code—no sign-up necessary.
+The Code payments platform makes accepting small payments on the web simple.
+It’s open, permissionless, and requires just a few lines of code—no sign-up
+necessary.
 
 After a decade of building consumer platforms and developer tools, we realized
 traditional payment systems are too limiting—they offer only large, one-way
 payments, involve complex onboarding, and charge high fees. The Code SDK lets
 you embed a "Pay with Code" button to charge as little as 5 cents per
 transaction, with only a flat 1-penny fee to cover blockchain costs.
-
-## What is the Code SDK?
-
-It’s a collection of JavaScript, TypeScript, Go, Python, and PHP packages that
-let you integrate Code into your website or web app—on both the client and
-server sides.
 
 ## What is Code?
 
@@ -24,3 +18,17 @@ the hassle of managing private keys, gas fees, or slow transactions. Built on
 the [Solana](https://solana.com/) blockchain and powered by the [Code
 Sequencer](../reference/sequencer), Code delivers an instant, global, and
 private payments experience.
+
+## What is the Code SDK?
+
+It’s a collection of JavaScript, TypeScript, Go, Python, and PHP packages that
+let you integrate Code into your website or web app—on both the client and
+server sides. 
+
+The SDK provides a simple interface to the Code API.
+
+## What is the Code API?
+
+The Code API is a gRPC-based API that lets you interact with the Code Sequencer.
+It’s used to create payment intents, verify payments, and more.
+

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Learn how to embed a [Code Payments](https://www.codepayments.org/) button in your website or web app. The client- and server-side code mounts everything needed to complete a payment using the Code app and verify it on your server.
+Learn how to embed a Code payments button in your website or web app. The client- and server-side code mounts everything needed to complete a payment using the Code app and verify it on your server.
 
 ## Create a Payment Button
 

--- a/docs/intents/custom-backends.md
+++ b/docs/intents/custom-backends.md
@@ -1,16 +1,106 @@
-# Custom Backends
+# Code API
 
-Code uses the concept of a payment intent to represent a user's intent to pay another user. This is different from a blockchain transaction. A payment intent is a higher-level abstraction that represents a user's intent to pay another user which is a way to represent a payment in a way that's more familiar to users.
+The Code API is a [gRPC API](https://grpc.io/) that you can use to send payment intents, login with code, check the status of a payment, verify the payment on your server, and many other things. The API is language-agnostic, which means you can use any language that supports gRPC to interact with the Code API.
 
-Unless you have a specific reason to use a custom backend, we recommend using one of our SDK [packages](../guide/installation#packages) to construct the payment request intent. You can learn more about the payment flow [here](../intents/payment-requests).
+If there is a feature that you need that isn't supported by the SDKs yet, you can call the Code API directly. This is useful if you're using a language that isn't supported by the SDKs yet or if you need to implement a custom backend.
 
-::: warning
-This page is strictly for those who want to use a custom backend or a language that isn't supported yet. This is an advanced topic and we recommend using one of our SDKs to construct the payment request intent.
+::: info 
+We recommend using the SDKs to interact with the Code API. The SDKs handle the low-level details of constructing the binary blob that represents the payment intent and signing it with the rendezvous key.
 :::
 
-## Payment Request Intents
+## Getting Started
 
-If you'd like to use a custom backend or a language that isn't supported yet, it is possible to call our `createIntent` API directly. 
+To get started with the Code API, you'll need to:
+
+1. Find the [protobuf definition](https://github.com/code-payments/code-protobuf-api) for the message you want to send.
+2. Construct the binary blob that represents the message.
+3. Sign the binary blob
+4. Send the signed binary blob to the Code API
+
+The Code API contains a slew of messages that you can send. Each message has its own protobuf definition for the request and response structure.
+
+::: tip
+Take a look at the internals of the SDKs to see how the binary blob is constructed and signed. This will give you a good idea of how to construct the binary blob yourself.
+
+* [TypeScript Example](https://github.com/code-payments/code-sdk/tree/94c5cfa6dc84d380a60b9651b17ddad23b7ad3dc/packages/intents/src/intents)
+* [Python Example](https://github.com/code-payments/code-sdk-python/blob/main/code_wallet/library/payment_request.py)
+* [Go Example](https://github.com/code-payments/code-sdk-go/blob/main/sdk/payment_request.go)
+* [PHP Example](https://github.com/code-payments/code-sdk-php/tree/main/src/messages)
+:::
+
+## gRPC Proxy
+
+We provide a gRPC proxy that you can use to interact with the Code API without needing to open a socket connection. This is far easier than opening a socket connection and is the recommended way to interact with the Code API. You can also run the proxy on your own server if you'd like.
+
+We use a custom gRPC envelope protocol as the existing gRPC-web libraries do not support bidi streams over HTTP/1 and are [not binary stable](https://github.com/protocolbuffers/protobuf-go/blob/v1.28.1/proto/encode.go#L216-L219). When using the proxy, you'll have to wrap your message in an [envelope](https://github.com/code-payments/code-protobuf-api/blob/05e5a67f9e57da8cdeaac122b0256cb997459a69/proto/common/v1/model.proto#L175-L194), but otherwise it is the same. The proxy will take care of the gRPC communication for you.
+
+Additionally, the proxy is available over HTTP/1.1, which means you can use it in a browser environment.
+
+**Proxy URL (HTTP/1.1)**
+```raw
+https://api.getcode.com/v1
+```
+
+Or you can use the direct gRPC URL, which does require a grpc socket connection.
+
+**Direct gRPC URL (HTTP/2)**
+```raw
+https://api.codeinfra.net
+```
+
+::: tip
+Take a look at the [gRPC proxy](https://github.com/code-payments/code-sdk/tree/main/packages/proxy) and each of the SDKs to see how they interact with the Code API.
+
+* [TypeScript Request](https://github.com/code-payments/code-sdk/blob/94c5cfa6dc84d380a60b9651b17ddad23b7ad3dc/packages/client/src/client.ts#L50-L55)
+* [Python Request](https://github.com/code-payments/code-sdk-python/blob/2c88e663ccc5e89edb93db5f931bdadb42ccfc1d/code_wallet/client/connection.py#L43-L65)
+* [Go Request](https://github.com/code-payments/code-sdk-go/blob/34915b560481a6db8035433dabc2897e388ba8d7/sdk/client.go#L71-L85)
+* [PHP Request](https://github.com/code-payments/code-sdk-php/blob/0a2fd9a50706953c3d991a7eca4db014ce496975/src/client/Connection.php#L49-L79)
+:::
+
+## Protobuf 
+
+A protobuf definition is a way to define the structure of a message. A protobuf definition is a `.proto` file that defines the structure of a message. It can be compiled into code for many different languages.
+
+All the protobuf definitions for the Code API can be found [here](https://github.com/code-payments/code-protobuf-api). Nearly every language has a protobuf library that can be used to construct the binary blob. You can also construct the binary blob by hand.
+
+If you're unsure about the content of a signed message, how to construct it, where to submit it, or how to verify it, please take a look at the [Typescript](https://github.com/code-payments/code-sdk/blob/main/packages/intents/src/intents/) intents. These are the most up-to-date and accurate representations of the signed messages.
+
+## Intents
+
+Code uses the concept of an intent to represent a user's desired actions. This is different from a blockchain transaction. An intent is a higher-level abstraction.
+
+The Code Sequencer expects a binary blob that represents the intent. The binary blob is constructed using the protobuf definition. When you call the `createIntent` API, you'll need to construct the binary blob yourself and sign it with the [rendezvous key](../reference/rendezvous). 
+
+We have several intent types, such as `RequestToReceiveBill`, `RequestToPayBill`, and `RequestToLogin`. Each intent type has its own protobuf definition.
+
+At a high level, the intent structure looks like this:
+
+```protobuf
+message Message {
+    MessageId id = 1;
+    Signature send_message_request_signature = 3;
+
+    oneof kind {
+        RequestToGrabBill     request_to_grab_bill     = 2;
+        RequestToReceiveBill  request_to_receive_bill  = 5;
+        CodeScanned           code_scanned             = 6;
+        ClientRejectedPayment client_rejected_payment  = 7;
+        IntentSubmitted       intent_submitted         = 8;
+        WebhookCalled         webhook_called           = 9;
+        RequestToLogin        request_to_login         = 10;
+        ClientRejectedLogin   client_rejected_login    = 12;
+        AirdropReceived       airdrop_received         = 4;
+    }
+}
+```
+
+The SDKs are basically wrappers around this protobuf definition. They construct the binary blob for you and sign it with the rendezvous key. If you'd like to use a custom backend or a language that isn't supported yet, it is possible to call our `createIntent` API directly. 
+
+## Example Requests
+
+Below are some examples of how to construct the binary blob for a payment intent and a login intent. These examples are based on the protobuf definitions provided earlier.
+
+## Payment Requests
 
 A typical server-side integration will look something like this:
 
@@ -18,14 +108,14 @@ A typical server-side integration will look something like this:
 sequenceDiagram
   autonumber
   participant User
-  participant Client
+  participant Browser
 
-  User->>Client: Land on payment page
-  Client->>Server: Send order information
+  User->>Browser: Lands on payment page
+  Browser->>Server: Sends order information
   Server->>Code Sequencer: POST /v1/createIntent
-  Code Sequencer->>Server: Return PaymentIntent status
-  Server->>Client: Return PaymentIntent's client_secret
-  Client->>Code Sequencer: Open message stream at rendezvous value
+  Code Sequencer->>Server: Returns PaymentIntent status
+  Server->>Browser: Returns PaymentIntent's client_secret
+  Browser->>Code Sequencer: Opens message stream at rendezvous value
 ```
 
 You can learn more about the payment flow [here](../intents/payment-requests).
@@ -34,10 +124,9 @@ You can learn more about the payment flow [here](../intents/payment-requests).
 In order to call the `createIntent` API manually, you'll need to construct the payment intent binary blob yourself and sign it with the [rendezvous key](../reference/rendezvous). 
 
 You can do that one of two ways:
-* Use a protobuf library to construct the binary blob
+* **Use a protobuf library to construct the binary blob**
 * Construct the binary blob manually
 
-### Protobuf
 The protobuf defenition for `RequestToReceiveBill` is as follows:
 
 ```protobuf
@@ -85,7 +174,7 @@ message ExchangeDataWithoutRate {
 }
 ```
 
-### Example
+#### Constructing the binary blob manually
 
 Given the above protobuf definition, you can construct a payment intent as follows:
 
@@ -99,7 +188,15 @@ Given the above protobuf definition, you can construct a payment intent as follo
 ]
 ```
 
+#### Decoding the binary blob
+
 Let's decode the given binary serialization based on the protobuf definitions provided earlier.
+
+::: info NOTE
+We don't recommend constructing the binary blob manually unless you have a specific reason to do so. It's error-prone and can lead to unexpected behavior.
+
+We describe it here to give you an idea of how the payment intent is constructed and to remove the mystery around the SDKs.
+:::
 
 #### Message structure
 * `0x2A`: This indicates field number 5 (`request_to_receive_bill`) with a wire type of 2 (length-delimited).
@@ -142,3 +239,73 @@ This is then signed using the rendezvous key and `POST`ed to the Code Sequencer'
 
 You can see an example of this in our [Python SDK](https://github.com/code-payments/code-sdk-python/blob/main/code_wallet/library/message.py).
 
+## Login intents
+
+The **Login with Code** flow consists of the following steps, you can learn more about the login flow [here](../intents/login).
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant User
+  participant Browser
+
+  User->>Browser: Lands on login page
+  Browser->>Server: Sends login request
+  Server->>Code Sequencer: POST /v1/createIntent
+  Code Sequencer->>Server: Returns LoginIntent status
+  Server->>Browser: Returns LoginIntent's client_secret
+  Browser->>Code Sequencer: Open message stream at rendezvous value
+```
+
+The login flow is similar to the payment flow, but instead of a payment intent, you'll be creating a login intent. The login intent is a higher-level abstraction that represents a user's intent to log in to a website or application.
+
+The protobuf definition for [RequestToLogin](https://github.com/code-payments/code-protobuf-api/blob/05e5a67f9e57da8cdeaac122b0256cb997459a69/proto/messaging/v1/messaging_service.proto#L318-L342) is as follows:
+
+```Protobuf
+message Domain {
+  string domain = 1;
+}
+
+message SolanaAccountId {
+  bytes value = 1;
+}
+
+message Signature {
+  bytes value = 1;
+}
+
+message RendezvousKey {
+  bytes value = 1;
+}
+
+message Message {
+    MessageId id = 1;
+    Signature send_message_request_signature = 3;
+
+    oneof kind {
+        RequestToLogin request_to_login = 10;
+    }
+}
+
+message RequestToLogin {
+  Domain domain = 1;
+  SolanaAccountId verifier = 4;
+  Signature signature = 5;
+  RendezvousKey rendezvous_key = 6;
+}
+
+```
+
+You can construct a login intent using similar logic as the payment intent, but
+with the [RequestToLogin](https://github.com/code-payments/code-protobuf-api/blob/05e5a67f9e57da8cdeaac122b0256cb997459a69/proto/messaging/v1/messaging_service.proto#L318-L342) protobuf definition. 
+
+::: tip NOTE
+Use the [TypeScript](https://github.com/code-payments/code-sdk/blob/main/packages/intents/src/intents/LoginRequestIntent.ts#L82-L139)
+version as a reference for constructing the binary blob.
+:::
+
+## Contributing
+
+If you're interested in contributing to the Code SDK, or one of our variants, please reach out to us on [Discord](https://discord.gg/T8Tpj8DBFp) or [Twitter](https://twitter.com/getcode). We're always looking for help with new SDK features, documentation, and examples.
+
+If there is a feature that you need that isn't supported by the SDKs yet, it is likely that someone else needs it too. We can work together to add the feature to the SDKs.

--- a/docs/intents/custom-backends.md
+++ b/docs/intents/custom-backends.md
@@ -1,40 +1,69 @@
-# Code API
+# Code API {#introduction}
 
-The Code API is a [gRPC API](https://grpc.io/) that you can use to send payment intents, login with code, check the status of a payment, verify the payment on your server, and many other things. The API is language-agnostic, which means you can use any language that supports gRPC to interact with the Code API.
+The Code API is a [gRPC API](https://grpc.io/) service designed to handle various actions such as creating `Payment Requests`, `Login With Code`, checking intent status, and more. Being language-agnostic, you can use any programming language that supports gRPC to interact with the Code API.
 
-If there is a feature that you need that isn't supported by the SDKs yet, you can call the Code API directly. This is useful if you're using a language that isn't supported by the SDKs yet or if you need to implement a custom backend.
+If you require a feature that isn't yet supported by our SDKs, you can directly call the Code API. This approach is particularly useful if you're working with an unsupported language or need to implement something more custom.
 
-::: info 
-We recommend using the SDKs to interact with the Code API. The SDKs handle the low-level details of constructing the binary blob that represents the payment intent and signing it with the rendezvous key.
+::: info Recommendation
+When possible, we encourage using our SDKs to interact with the Code API. The SDKs manage the low-level details of constructing the binary blob that represents the payment Intent and signing it with the [rendezvous key](../reference/rendezvous).
 :::
 
-## Getting Started
+## Getting Started {#getting-started}
 
-To get started with the Code API, you'll need to:
+To begin using the Code API, follow these steps:
 
-1. Find the [protobuf definition](https://github.com/code-payments/code-protobuf-api) for the message you want to send.
-2. Construct the binary blob that represents the message.
-3. Sign the binary blob
-4. Send the signed binary blob to the Code API
+1. **Fimilarize yourself with [Protobuf](https://developers.google.com/protocol-buffers)**, the serialization format used by the Code API.
+2. **Locate the [Protobuf Definition](https://github.com/code-payments/code-protobuf-api)** for the message you intend to send.
+3. **Construct the binary blob** representing the message.
+4. **Sign the binary blob** with your [rendezvous key](../reference/rendezvous).
+5. **Send the signed binary blob** to the Code API.
 
-The Code API contains a slew of messages that you can send. Each message has its own protobuf definition for the request and response structure.
+The Code API supports a wide range of messages, each with its own Protobuf definition for request and response structures.
+
+## Protobuf {#protobuf}
+
+We use [Protocol Buffers](https://developers.google.com/protocol-buffers) (protobuf) to define the structure of messages sent to and received from the Code API.
+
+A protobuf definition is a way to define the structure of a message; simply a text file with a `.proto` extension. This file can be compiled into source code for many different languages. These can then be used to serialize and deserialize messages into a binary format (more compact).
+
+```proto
+syntax = "proto3";
+
+message Person {
+  string name = 1; // Field number 1
+  int32 age = 2;   // Field number 2
+}
+```
+
+All the protobuf definitions for the Code API can be found [here](https://github.com/code-payments/code-protobuf-api). Nearly every language has a protobuf library that can be used to construct the binary blob. **You can also construct the binary blob by hand**. 
 
 ::: tip
-Take a look at the internals of the SDKs to see how the binary blob is constructed and signed. This will give you a good idea of how to construct the binary blob yourself.
-
-* [TypeScript Example](https://github.com/code-payments/code-sdk/tree/94c5cfa6dc84d380a60b9651b17ddad23b7ad3dc/packages/intents/src/intents)
-* [Python Example](https://github.com/code-payments/code-sdk-python/blob/main/code_wallet/library/payment_request.py)
-* [Go Example](https://github.com/code-payments/code-sdk-go/blob/main/sdk/payment_request.go)
-* [PHP Example](https://github.com/code-payments/code-sdk-php/tree/main/src/messages)
+You can play around with the [Protobuf Playground](https://www.protobufpal.com/) to get a feel for how it works.
 :::
 
-## gRPC Proxy
+If you're unsure about the content of a signed message, how to construct it, where to submit it, or how to verify it, please take a look at the [TypeScript](https://github.com/code-payments/code-sdk/blob/main/packages/intents/src/intents/) intents. These are the most up-to-date and accurate representations of the signed messages.
 
-We provide a gRPC proxy that you can use to interact with the Code API without needing to open a socket connection. This is far easier than opening a socket connection and is the recommended way to interact with the Code API. You can also run the proxy on your own server if you'd like.
+## gRPC {#grpc}
 
-We use a custom gRPC envelope protocol as the existing gRPC-web libraries do not support bidi streams over HTTP/1 and are [not binary stable](https://github.com/protocolbuffers/protobuf-go/blob/v1.28.1/proto/encode.go#L216-L219). When using the proxy, you'll have to wrap your message in an [envelope](https://github.com/code-payments/code-protobuf-api/blob/05e5a67f9e57da8cdeaac122b0256cb997459a69/proto/common/v1/model.proto#L175-L194), but otherwise it is the same. The proxy will take care of the gRPC communication for you.
+While we use `protobuf` to define the structure of messages, we use `gRPC` to send and receive these messages. The gRPC protocol is a high-performance, open-source, universal RPC framework. It is designed and maintained by Google.
+
+We make use of gRPC tooling that generates client and server code in multiple languages, making it easy to interact with the Code API.
+
+### Web Proxy {#grpc-proxy}
+
+Typically, gRPC requires a direct socket connection to the server. However, this can be difficult to set up in some environments. **Specifically, it can be challenging to use gRPC in a browser environment**.
+
+We provide a custom `HTTP/1.1` gRPC proxy that you can use to interact with the Code API without needing to open a socket connection. This is far easier than opening a socket connection and is the recommended way to interact with the Code API. You can also run the proxy on your own server if you'd like.
 
 Additionally, the proxy is available over HTTP/1.1, which means you can use it in a browser environment.
+
+::: info Recommendation
+We recommend using the gRPC proxy to interact with the Code API. It allows you to use simple `fetch(...)` requests to interact with the API instead of opening a socket connection.
+:::
+
+## Mainnet Endpoints {#endpoints}
+
+You can use the following URLs to interact with the Code API:
 
 **Proxy URL (HTTP/1.1)**
 ```raw
@@ -48,34 +77,342 @@ Or you can use the direct gRPC URL, which does require a grpc socket connection.
 https://api.codeinfra.net
 ```
 
-::: tip
-Take a look at the [gRPC proxy](https://github.com/code-payments/code-sdk/tree/main/packages/proxy) and each of the SDKs to see how they interact with the Code API.
+## Building Your Own Client {#building-a-client}
 
-* [TypeScript Request](https://github.com/code-payments/code-sdk/blob/94c5cfa6dc84d380a60b9651b17ddad23b7ad3dc/packages/client/src/client.ts#L50-L55)
-* [Python Request](https://github.com/code-payments/code-sdk-python/blob/2c88e663ccc5e89edb93db5f931bdadb42ccfc1d/code_wallet/client/connection.py#L43-L65)
-* [Go Request](https://github.com/code-payments/code-sdk-go/blob/34915b560481a6db8035433dabc2897e388ba8d7/sdk/client.go#L71-L85)
-* [PHP Request](https://github.com/code-payments/code-sdk-php/blob/0a2fd9a50706953c3d991a7eca4db014ce496975/src/client/Connection.php#L49-L79)
+When the SDK doesn’t yet support a feature you need, you can build your own client to interact directly with the Code API. In this section, we explain the Code API `envelope protocol` and provide minimal examples using JavaScript, Python, PHP, and Go.
+
+### Request/Response Protocol (HTTP/1.1)
+
+The Code API wraps your inner messages (such as a payment or login Intent) in a simple envelope defined using Protocol Buffers. If you're using our `HTTP/2` endpoint, you can skip this section.
+
+The proto definitions are:
+
+```proto
+syntax = "proto3";
+
+message Request {
+    string version = 1;
+    string service = 2;
+    string method = 3;
+    bytes body = 4;
+}
+
+message Response {
+    Result result = 1;
+    bytes body = 2;
+    string message = 3;
+
+    enum Result {
+        OK = 0;
+        ERROR = 1;
+    }
+}
+```
+
+#### Request Fields:
+
+- **version**: The API version (e.g. `"1.0"`).
+- **service**: The target service (e.g. `"Intents"`).
+- **method**: The method to invoke (e.g. `"createIntent"`).
+- **body**: The binary-serialized payload of your inner message.
+
+#### Response Fields:
+
+- **result**: The outcome of the request (`OK` or `ERROR`).
+- **body**: The binary-encoded response payload.
+
+For example, the following `Request`:
+
+```json
+{
+  "version": "1.0",
+  "service": "Intents",
+  "method": "createIntent", 
+  "body": [1, 2, 3, 4]
+}
+```
+
+Serializes to the following hex string:
+
+```raw
+0a03312e301207496e74656e74731a0c637265617465496e74656e74220401020304
+```
+
+### Sending a Request 
+Below is a minimal JavaScript example that wraps your protobuf-serialized payload in a `Request` envelope and sends it via `HTTP/1.1` POST.
+
+::: code-group
+
+```javascript [js]
+import { Request, Response } from '@code-wallet/rpc';
+
+// Assume you already have your payload message 
+// (e.g. a payment or login Intent) that has been 
+// encoded (and signed) using its protobuf definition.
+const payload = myProtoMessage.toBinary();
+
+// Wrap the payload in a Request envelope
+const envelope = new Request({
+  version: "1.0",
+  service: "Intents",     // e.g. "Intents"
+  method: "createIntent", // e.g. "createIntent"
+  body: payload,
+});
+
+// Serialize the envelope to binary
+const binaryEnvelope = envelope.toBinary();
+
+// Send the binary envelope using an HTTP POST
+fetch("https://api.getcode.com/api/", {
+  method: "POST",
+  headers: { "Content-Type": "application/octet-stream" },
+  body: binaryEnvelope,
+})
+  .then(response => response.arrayBuffer())
+  .then(buffer => {
+    // Decode the response envelope from binary
+    const resEnvelope = Response.fromBinary(new Uint8Array(buffer));
+    console.log("Received response:", resEnvelope);
+  })
+  .catch(err => console.error("Network error:", err));
+```
+
+```python [python]
+import requests
+
+# We don't yet have a Python library for encoding/decoding 
+# the CodeAPI protobuf messages. 
+
+# However, you can build your own.
+# More details here: https://protobuf.dev/getting-started/pythontutorial/
+
+# In this example, we're just going to do it 
+# manually (not recommended but simple).
+def encode_varint(value):
+    """Encode an integer as a protobuf varint."""
+    result = bytearray()
+    while True:
+        to_write = value & 0x7F
+        value >>= 7
+        if value:
+            result.append(to_write | 0x80)
+        else:
+            result.append(to_write)
+            break
+    return bytes(result)
+
+def encode_length_delimited(field_number, data_bytes):
+    """
+    Encode a length-delimited field.
+    For proto fields of type string or bytes:
+      - Tag: (field_number << 3) | 2 (wire type 2)
+      - Length: varint-encoded length of data_bytes
+      - Value: the raw bytes
+    """
+    tag = (field_number << 3) | 2
+    return encode_varint(tag) + encode_varint(len(data_bytes)) + data_bytes
+
+# Prepare the fields for the Request message.
+version = "1.0".encode("utf-8")
+service = "Intents".encode("utf-8")
+method  = "createIntent".encode("utf-8")
+body    = bytes([1, 2, 3, 4])  # Example payload
+
+# Manually serialize the Request message by concatenating each field.
+serialized = (
+    encode_length_delimited(1, version) +
+    encode_length_delimited(2, service) +
+    encode_length_delimited(3, method) +
+    encode_length_delimited(4, body)
+)
+
+# The expected hex serialization:
+# 0a03312e301207496e74656e74731a0c637265617465496e74656e74220401020304
+print("Serialized Request:", serialized.hex())
+
+# Send the serialized request via HTTP POST.
+response = requests.post(
+    "https://api.getcode.com/api/",
+    headers={"Content-Type": "application/octet-stream"},
+    data=serialized
+)
+
+if response.ok:
+    # For demonstration, print the raw response bytes in hex.
+    print("Response:", response.content.hex())
+else:
+    print("Request failed with status code:", response.status_code)
+
+```
+
+```php [php]
+# We don't yet have a Php library for encoding/decoding 
+# the CodeAPI protobuf messages.
+
+# In this example, we're just going to do it 
+# manually (not recommended but simple).
+
+function encodeVarint($value) {
+    $result = '';
+    while (true) {
+        $toWrite = $value & 0x7F;
+        $value >>= 7;
+        if ($value) {
+            $result .= chr($toWrite | 0x80);
+        } else {
+            $result .= chr($toWrite);
+            break;
+        }
+    }
+    return $result;
+}
+
+function encodeLengthDelimited($fieldNumber, $dataBytes) {
+    $tag = ($fieldNumber << 3) | 2;
+    return encodeVarint($tag) . encodeVarint(strlen($dataBytes)) . $dataBytes;
+}
+
+// Prepare the fields for the Request message.
+$version = "1.0";
+$service = "Intents";
+$method  = "createIntent";
+$body    = chr(1) . chr(2) . chr(3) . chr(4);  // Example payload
+
+// Manually serialize the Request message.
+$serialized = 
+    encodeLengthDelimited(1, $version) .
+    encodeLengthDelimited(2, $service) .
+    encodeLengthDelimited(3, $method) .
+    encodeLengthDelimited(4, $body);
+
+echo "Serialized Request: " . bin2hex($serialized) . "\n";
+
+// Send the serialized request via HTTP POST using cURL.
+$ch = curl_init("https://api.getcode.com/api/");
+curl_setopt($ch, CURLOPT_POST, true);
+curl_setopt($ch, CURLOPT_HTTPHEADER, array("Content-Type: application/octet-stream"));
+curl_setopt($ch, CURLOPT_POSTFIELDS, $serialized);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+$response = curl_exec($ch);
+if (curl_errno($ch)) {
+    echo "Request failed: " . curl_error($ch) . "\n";
+} else {
+    echo "Response: " . bin2hex($response) . "\n";
+}
+curl_close($ch);
+
+```
+
+```go [go]
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+// You can use our library to encode/decode the CodeAPI protobuf messages.
+// https://github.com/code-payments/code-protobuf-api/tree/main/generated/go
+
+// We're going to do it manually (not recommended but simple).
+func encodeVarint(value uint64) []byte {
+	var buf []byte
+	for {
+		b := byte(value & 0x7F)
+		value >>= 7
+		if value != 0 {
+			buf = append(buf, b|0x80)
+		} else {
+			buf = append(buf, b)
+			break
+		}
+	}
+	return buf
+}
+
+func encodeLengthDelimited(fieldNumber int, data []byte) []byte {
+	tag := uint64((fieldNumber << 3) | 2)
+	var buf bytes.Buffer
+	buf.Write(encodeVarint(tag))
+	buf.Write(encodeVarint(uint64(len(data))))
+	buf.Write(data)
+	return buf.Bytes()
+}
+
+func main() {
+	version := []byte("1.0")
+	service := []byte("Intents")
+	method := []byte("createIntent")
+	body := []byte{1, 2, 3, 4} // Example payload
+
+	var serialized bytes.Buffer
+	serialized.Write(encodeLengthDelimited(1, version))
+	serialized.Write(encodeLengthDelimited(2, service))
+	serialized.Write(encodeLengthDelimited(3, method))
+	serialized.Write(encodeLengthDelimited(4, body))
+
+	serializedBytes := serialized.Bytes()
+	fmt.Println("Serialized Request:", hex.EncodeToString(serializedBytes))
+
+	// Send HTTP POST
+	resp, err := http.Post(
+        "https://api.getcode.com/api/", 
+        "application/octet-stream",
+        bytes.NewReader(serializedBytes)
+    )
+	if err != nil {
+		fmt.Println("Request failed:", err)
+		return
+	}
+	defer resp.Body.Close()
+	responseBody, _ := ioutil.ReadAll(resp.Body)
+	fmt.Println("Response:", hex.EncodeToString(responseBody))
+}
+```
 :::
 
-## Protobuf 
+The above examples show how to construct a `Request` envelope and send it to the Code API. The response is also wrapped in a `Response` envelope. You can then extract the binary-encoded payload from the response and decode it using the appropriate protobuf definition.
 
-A protobuf definition is a way to define the structure of a message. A protobuf definition is a `.proto` file that defines the structure of a message. It can be compiled into code for many different languages.
+You can learn more about the payload structure below.
 
-All the protobuf definitions for the Code API can be found [here](https://github.com/code-payments/code-protobuf-api). Nearly every language has a protobuf library that can be used to construct the binary blob. You can also construct the binary blob by hand.
+::: info
+Take a look at the following client implementations that use our `HTTP/1.1` gRPC proxy.
 
-If you're unsure about the content of a signed message, how to construct it, where to submit it, or how to verify it, please take a look at the [Typescript](https://github.com/code-payments/code-sdk/blob/main/packages/intents/src/intents/) intents. These are the most up-to-date and accurate representations of the signed messages.
+* [TypeScript Client](https://github.com/code-payments/code-sdk/blob/94c5cfa6dc84d380a60b9651b17ddad23b7ad3dc/packages/client/src/client.ts#L50-L55)
+* [Python Client](https://github.com/code-payments/code-sdk-python/blob/2c88e663ccc5e89edb93db5f931bdadb42ccfc1d/code_wallet/client/connection.py#L43-L65)
+* [Go Client](https://github.com/code-payments/code-sdk-go/blob/34915b560481a6db8035433dabc2897e388ba8d7/sdk/client.go#L71-L85)
+* [PHP Client](https://github.com/code-payments/code-sdk-php/blob/0a2fd9a50706953c3d991a7eca4db014ce496975/src/client/Connection.php#L49-L79)
+:::
 
-## Intents
+### HTTP/2 gRPC Endpoint
 
-Code uses the concept of an intent to represent a user's desired actions. This is different from a blockchain transaction. An intent is a higher-level abstraction.
+Additionally, you can also use our `HTTP/2` gRPC endpoint directly. This requires a gRPC client library that supports gRPC over `HTTP/2`. 
 
-The Code Sequencer expects a binary blob that represents the intent. The binary blob is constructed using the protobuf definition. When you call the `createIntent` API, you'll need to construct the binary blob yourself and sign it with the [rendezvous key](../reference/rendezvous). 
+Our golang, iOS and Android SDKs use this method.
 
-We have several intent types, such as `RequestToReceiveBill`, `RequestToPayBill`, and `RequestToLogin`. Each intent type has its own protobuf definition.
+::: info
+Take a look at the following client implementations that use our `HTTP/2` gRPC endpoint directly.
 
-At a high level, the intent structure looks like this:
+* [Go Client](https://github.com/code-payments/code-protobuf-api/tree/main/generated/go)
+* [Swift Client](https://github.com/code-payments/code-ios-app/tree/main/CodeServices/Sources/CodeServices/API)
+* [Kotlin Client](https://github.com/code-payments/code-android-app/tree/main/api)
+:::
 
-```protobuf
+## Intents {#intents}
+
+Code uses the concept of an [Intent](../intents/introduction.md) to represent a user's desired actions. This is different from a blockchain transaction. An Intent is a higher-level abstraction.
+
+The Code Sequencer expects a binary blob that represents the Intent. The binary blob is constructed using the protobuf definition. When you call the `createIntent` API, you'll need to construct the binary blob yourself and sign it with the [rendezvous key](../reference/rendezvous). 
+
+We have several Intent types, such as `RequestToReceiveBill`, `RequestToPayBill`, and `RequestToLogin`. Each Intent type has its own protobuf definition.
+
+At a high level, the Intent structure looks like this:
+
+```proto
 message Message {
     MessageId id = 1;
     Signature send_message_request_signature = 3;
@@ -96,11 +433,18 @@ message Message {
 
 The SDKs are basically wrappers around this protobuf definition. They construct the binary blob for you and sign it with the rendezvous key. If you'd like to use a custom backend or a language that isn't supported yet, it is possible to call our `createIntent` API directly. 
 
-## Example Requests
+::: info
+Take a look at the internals of the SDKs to see how the binary blob is constructed and signed. This will give you a good idea of how to construct the binary blob yourself.
 
-Below are some examples of how to construct the binary blob for a payment intent and a login intent. These examples are based on the protobuf definitions provided earlier.
+* [TypeScript Example](https://github.com/code-payments/code-sdk/tree/94c5cfa6dc84d380a60b9651b17ddad23b7ad3dc/packages/intents/src/intents)
+* [Python Example](https://github.com/code-payments/code-sdk-python/blob/main/code_wallet/library/payment_request.py)
+* [Go Example](https://github.com/code-payments/code-sdk-go/blob/main/sdk/payment_request.go)
+* [PHP Example](https://github.com/code-payments/code-sdk-php/tree/main/src/messages)
+:::
 
-## Payment Requests
+Below are some examples of how to construct the binary blob for a payment Intent and a login Intent. These examples are based on the protobuf definitions provided earlier. You'll need to sign and wrap these payloads in a `Request` envelope before sending them to the Code API.
+
+### Payment Example {#payment-requests}
 
 A typical server-side integration will look something like this:
 
@@ -120,16 +464,16 @@ sequenceDiagram
 
 You can learn more about the payment flow [here](../intents/payment-requests).
 
-
-In order to call the `createIntent` API manually, you'll need to construct the payment intent binary blob yourself and sign it with the [rendezvous key](../reference/rendezvous). 
+In order to call the `createIntent` API manually, you'll need to construct the payment Intent binary blob yourself and sign it with the [rendezvous key](../reference/rendezvous). 
 
 You can do that one of two ways:
 * **Use a protobuf library to construct the binary blob**
 * Construct the binary blob manually
 
-The protobuf defenition for `RequestToReceiveBill` is as follows:
+The protobuf defenition for `RequestToReceiveBill` is as follows (full definition can be found [here](https://github.com/code-payments/code-protobuf-api)):
 
-```protobuf
+```proto
+syntax = "proto3";
 
 message SolanaAccountId {
     bytes value = 1;
@@ -176,7 +520,7 @@ message ExchangeDataWithoutRate {
 
 #### Constructing the binary blob manually
 
-Given the above protobuf definition, you can construct a payment intent as follows:
+Given the above protobuf definition, you can construct a payment Intent as follows:
 
 ```raw
 [
@@ -192,10 +536,10 @@ Given the above protobuf definition, you can construct a payment intent as follo
 
 Let's decode the given binary serialization based on the protobuf definitions provided earlier.
 
-::: info NOTE
-We don't recommend constructing the binary blob manually unless you have a specific reason to do so. It's error-prone and can lead to unexpected behavior.
+::: info Recommendation
+We don't recommend constructing the binary blob manually unless you have a specific reason to do so. It's error-prone and can lead to unexpected behavior. Use a protobuf library to construct the binary blob.
 
-We describe it here to give you an idea of how the payment intent is constructed and to remove the mystery around the SDKs.
+https://protobuf.dev/getting-started/
 :::
 
 #### Message structure
@@ -239,7 +583,7 @@ This is then signed using the rendezvous key and `POST`ed to the Code Sequencer'
 
 You can see an example of this in our [Python SDK](https://github.com/code-payments/code-sdk-python/blob/main/code_wallet/library/message.py).
 
-## Login intents
+### Login Example {#login-intents}
 
 The **Login with Code** flow consists of the following steps, you can learn more about the login flow [here](../intents/login).
 
@@ -257,11 +601,13 @@ sequenceDiagram
   Browser->>Code Sequencer: Open message stream at rendezvous value
 ```
 
-The login flow is similar to the payment flow, but instead of a payment intent, you'll be creating a login intent. The login intent is a higher-level abstraction that represents a user's intent to log in to a website or application.
+The login flow is similar to the payment flow, but instead of a payment Intent, you'll be creating a login Intent. The login Intent is a higher-level abstraction that represents a user's Intent to log in to a website or application.
 
 The protobuf definition for [RequestToLogin](https://github.com/code-payments/code-protobuf-api/blob/05e5a67f9e57da8cdeaac122b0256cb997459a69/proto/messaging/v1/messaging_service.proto#L318-L342) is as follows:
 
-```Protobuf
+```proto
+syntax = "proto3";
+
 message Domain {
   string domain = 1;
 }
@@ -276,6 +622,10 @@ message Signature {
 
 message RendezvousKey {
   bytes value = 1;
+}
+
+message MessageId {
+    bytes value = 1;
 }
 
 message Message {
@@ -296,10 +646,10 @@ message RequestToLogin {
 
 ```
 
-You can construct a login intent using similar logic as the payment intent, but
+You can construct a login Intent using similar logic as the payment Intent, but
 with the [RequestToLogin](https://github.com/code-payments/code-protobuf-api/blob/05e5a67f9e57da8cdeaac122b0256cb997459a69/proto/messaging/v1/messaging_service.proto#L318-L342) protobuf definition. 
 
-::: tip NOTE
+::: info
 Use the [TypeScript](https://github.com/code-payments/code-sdk/blob/main/packages/intents/src/intents/LoginRequestIntent.ts#L82-L139)
 version as a reference for constructing the binary blob.
 :::

--- a/docs/intents/login.md
+++ b/docs/intents/login.md
@@ -22,6 +22,31 @@ To implement **Login with Code**, ensure you have the following:
    - The public key must be accessible from the root of your domain using **HTTPS** (not HTTP). 
    - Subdomains are **not** supported.
 
+## Flow Overview
+
+The **Login with Code** flow consists of the following steps, which are largely handled by the Code SDK:
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant User
+  participant Browser
+
+  User->>Browser: Lands on login page
+  Browser->>Server: Sends login request
+  Server->>Code Sequencer: POST /v1/createIntent
+  Code Sequencer->>Server: Returns LoginIntent status
+  Server->>Browser: Returns LoginIntent's client_secret
+  Browser->>Code Sequencer: Open message stream at rendezvous value
+```
+
+If you are using the Code SDK, you can create a login intent using the `code.loginIntents.create()` method. This method will return a `clientSecret` that you can use to authenticate the user. This `clientSecret` is used to create a button that will trigger the login flow.
+
+::: tip NOTE
+This feature is currently not supported by the PHP, Python, or Go libraries. These SDKs will be updated to support this feature in the future.
+
+In the meantime, you can achieve the same functionality by sending a POST containing a signed `RequestToLogin`. You can read more about this in our [Code API](./custom-backends) section.
+:::
 
 ## Example Login Integration
 
@@ -116,7 +141,7 @@ You should now have a working **Login with Code** integration that allows users 
   1. Use a verifier keypair to create a login intent.
   2. Deploy your verifier's public key at `https://yourdomain.com/.well-known/code-payments.json` using HTTPS.
   3. Ensure the public key is hosted at the root of your domain; subdomains are unsupported.
-  4. Hosting the `.well-known/code-payments.json` file over HTTP will **not** work—HTTPS is mandatory.
+  4. Hosting the `.well-known/code-payments.json` file over HTTP will **not** work—HTTPS is mandatory. 
 
 ## Further Reading
 

--- a/docs/intents/payment-fees.md
+++ b/docs/intents/payment-fees.md
@@ -59,6 +59,12 @@ const { button } = code.elements.create('button', {
 - **Fee Total:** The maximum fee percentage cannot exceed 10% of the payment amount.
 - **Compatibility:** Ensure that the destination addresses provided for fees are valid addresses.
 
+::: tip NOTE
+This feature is currently not supported by the PHP, Python, or Go libraries. These SDKs will be updated to support this feature in the future.
+
+In the meantime, you can achieve the same functionality by sending a POST containing a signed `RequestToReceiveBill`. You can read more about this in our [Code API](./custom-backends) section.
+:::
+
 ## Further Reading
 
 - [Payment Intents](../intents/introduction)


### PR DESCRIPTION
## Problem
Our developers have been waiting on us to implement SDK updates across various languages (PHP, Python, Go, etc.) to support advanced features. However, maintaining full feature parity across a wide range of SDKs has proven challenging. As a result, many devs are left waiting for SDK updates instead of leveraging the full capabilities of the Code API directly.

## Proposal
Rather than trying to update and maintain every SDK immediately, we propose expanding our documentation to include a comprehensive gRPC API section. 

This new section will:
* Educate developers on how to use the Code API directly for advanced integrations.
* Provide clear, step-by-step instructions and sample code for using the API over both HTTP/1.1 and HTTP/2.
* Encourage community contributions to the SDKs, enabling the community to help us fill in gaps and add features where they are most needed.

## Changes

New Documentation: A full, dedicated gRPC API section has been added to the docs. It details the Code API structure, including the request/response envelope, how to construct binary payloads (with examples for JavaScript, Python, PHP, and Go), and how to send requests via both HTTP/1.1 (using our gRPC proxy) and HTTP/2.